### PR TITLE
Implementing / Extending PHP's built-in interfaces causes an error

### DIFF
--- a/TokenReflection/Php/ReflectionClass.php
+++ b/TokenReflection/Php/ReflectionClass.php
@@ -252,7 +252,7 @@ class ReflectionClass extends InternalReflectionClass implements IReflection, To
 		if (null === $this->interfaces) {
 			$broker = $this->broker;
 			$interfaceNames = $this->getInterfaceNames();
-			$this->interfaces = array_combine($interfaceNames, array_map(function($interfaceName) use ($broker) {
+			$this->interfaces = empty($interfaceNames) ? array() : array_combine($interfaceNames, array_map(function($interfaceName) use ($broker) {
 				return $broker->getClass($interfaceName);
 			}, $interfaceNames));
 		}


### PR DESCRIPTION
When implementing (e.g. `class foo implements ArrayAccess`) or extending (e.g. `interface bar extends Iterator`) PHP's built-in interfaces, an `array_combine(): Both parameters should have at least 1 element` warning is raised, which is thrown as an `\Nette\FatalErrorException` exception and stops execution.

When `\TokenReflection\Php\ReflectionClass::getInterfaces()` gets called on the built-in interface, `getInterfaceNames()` returns an empty array, which eventually calls `array_combine()` with empty arrays as the arguments and causes the `Both parameters should have at least 1 element` warning.

I'm not sure why, but this doesn't happen with custom interfaces. It seems like getInterfaces() isn't getting called at all. Maybe a better solution would be to handle built-in interfaces in the same way custom ones are handled, instead of this patch.
