### PR TITLE
Support late static binding object initialization (`new static`)

### DIFF
--- a/TokenReflection/ReflectionFunctionBase.php
+++ b/TokenReflection/ReflectionFunctionBase.php
@@ -342,7 +342,7 @@ abstract class ReflectionFunctionBase extends ReflectionBase implements IReflect
 					switch ($type) {
 						case T_STATIC:
 							$type = $tokenStream->skipWhitespaces()->getType();
-							if (T_DOUBLE_COLON === $type) {
+							if (T_DOUBLE_COLON === $type || (isset($previousType) && $previousType === T_NEW)) {
 								// Late static binding call
 								break;
 							} elseif (T_VARIABLE !== $type) {
@@ -409,6 +409,7 @@ abstract class ReflectionFunctionBase extends ReflectionBase implements IReflect
 						default:
 							$tokenStream->skipWhitespaces();
 					}
+					$previousType = $type;
 				}
 			} elseif (';' !== $type) {
 				throw new Exception\Parse(sprintf('Invalid token found: "%s".', $tokenStream->getTokenName()), Exception\Parse::PARSE_CHILDREN_ERROR);

--- a/TokenReflection/ReflectionFunctionBase.php
+++ b/TokenReflection/ReflectionFunctionBase.php
@@ -343,7 +343,7 @@ abstract class ReflectionFunctionBase extends ReflectionBase implements IReflect
 						case T_STATIC:
 							$type = $tokenStream->skipWhitespaces()->getType();
 							if (T_DOUBLE_COLON === $type || (isset($previousType) && $previousType === T_NEW)) {
-								// Late static binding call
+								// Late static binding
 								break;
 							} elseif (T_VARIABLE !== $type) {
 								throw new Exception\Parse(sprintf('Invalid token found: "%s".', $tokenStream->getTokenName()), Exception\Parse::PARSE_CHILDREN_ERROR);


### PR DESCRIPTION
Currently, using late static binding object initialization (`new static`) looks like a malformed static variable declaration to ReflectionFunctionBase::parseStaticVariables():

```
Could not process file /var/www/workspace/.../component/Component.php.
Could not parse file contents.
Could not parse TokenReflection\ReflectionFileNamespace ...\component child elements.
Could not parse TokenReflection\ReflectionClass ...\component\Component child elements.
Could not parse TokenReflection\ReflectionMethod factory child elements.
Could not parse function/method "factory" static variables.
Invalid token found: "(".

#0 /usr/share/php/TokenReflection/ReflectionFunctionBase.php(285): TokenReflection\ReflectionFunctionBase->parseStaticVariables(Object(TokenReflection\Stream))
#1 /usr/share/php/TokenReflection/ReflectionBase.php(154): TokenReflection\ReflectionFunctionBase->parseChildren(Object(TokenReflection\Stream), Object(TokenReflection\ReflectionClass))
#2 /usr/share/php/TokenReflection/ReflectionClass.php(1493): TokenReflection\ReflectionBase->__construct(Object(TokenReflection\Stream), Object(TokenReflection\Broker), Object(TokenReflection\ReflectionClass))
#3 /usr/share/php/TokenReflection/ReflectionBase.php(154): TokenReflection\ReflectionClass->parseChildren(Object(TokenReflection\Stream), Object(TokenReflection\ReflectionFileNamespace))
#4 /usr/share/php/TokenReflection/ReflectionFileNamespace.php(274): TokenReflection\ReflectionBase->__construct(Object(TokenReflection\Stream), Object(TokenReflection\Broker), Object(TokenReflection\ReflectionFileNamespace))
#5 /usr/share/php/TokenReflection/ReflectionBase.php(154): TokenReflection\ReflectionFileNamespace->parseChildren(Object(TokenReflection\Stream), Object(TokenReflection\ReflectionFile))
#6 /usr/share/php/TokenReflection/ReflectionFile.php(232): TokenReflection\ReflectionBase->__construct(Object(TokenReflection\Stream), Object(TokenReflection\Broker), Object(TokenReflection\ReflectionFile))
#7 /usr/share/php/TokenReflection/ReflectionFile.php(54): TokenReflection\ReflectionFile->parse()
#8 /usr/share/php/TokenReflection/Broker.php(107): TokenReflection\ReflectionFile->__construct(Object(TokenReflection\Stream), Object(TokenReflection\Broker))
#9 /usr/share/php/ApiGen/Generator.php(159): TokenReflection\Broker->processFile('/var/www/worksp...')
#10 /usr/bin/apigen(66): ApiGen\Generator->parse()
#11 {main}
```

This patch fixes it by keeping track of the previous token type, and ignores T_STATIC that follows T_NEW.
