### PR TITLE
Fix fatal error when using broker without OPTION_SAVE_TOKEN_STREAM

### DIFF
--- a/TokenReflection/Broker/Backend/Memory.php
+++ b/TokenReflection/Broker/Backend/Memory.php
@@ -16,7 +16,7 @@
 namespace TokenReflection\Broker\Backend;
 
 use TokenReflection;
-use TokenReflection\Stream\StreamBase as Stream, TokenReflection\Exception, TokenReflection\Broker, TokenReflection\Php, TokenReflection\Dummy;
+use TokenReflection\Stream\FileStream, TokenReflection\Exception, TokenReflection\Broker, TokenReflection\Php, TokenReflection\Dummy;
 
 /**
  * Memory broker backend.
@@ -447,7 +447,7 @@ class Memory implements Broker\Backend
 			throw new Exception\Runtime(sprintf('File "%s" was not processed yet.', $fileName), Exception\Runtime::DOES_NOT_EXIST);
 		}
 
-		return true === $this->tokenStreams[$realName] ? new Stream($realName) : $this->tokenStreams[$realName];
+		return true === $this->tokenStreams[$realName] ? new FileStream($realName) : $this->tokenStreams[$realName];
 	}
 
 	/**


### PR DESCRIPTION
When using TokenReflection\Broker without OPTION_SAVE_TOKEN_STREAM, attempts to retrieve file tokens result in a fatal error.

This is due to the instantiation of an abstract class, StreamBase, where FileStream should be used.

This patch fixes this, rationale follows:
Namespace aliases changed and FileStream unconditionally used as the Stream alias was only used by this line, and only FileStreams can be retrieved by this function
