### PR TITLE
Fix Broker not caching namespaces properly

### DIFF
--- a/TokenReflection/Broker.php
+++ b/TokenReflection/Broker.php
@@ -351,7 +351,7 @@ class Broker
 
 		$namespace = $this->backend->getNamespace($namespaceName);
 		if (null !== $namespace) {
-			$this->cache[self::CACHE_NAMESPACE][$namespaceName] = $namespaceName;
+			$this->cache[self::CACHE_NAMESPACE][$namespaceName] = $namespace;
 		}
 
 		return $namespace;


### PR DESCRIPTION
Broker::getNamespace stores $namespaceName instead of $namespace in the cache.

This causes a fatal error when calling Broker::processFile - string passed where an IReflection was expected
