### PR TITLE
Fix problem with docBlock

### DIFF
--- a/TokenReflection/ReflectionElement.php
+++ b/TokenReflection/ReflectionElement.php
@@ -274,13 +274,14 @@ abstract class ReflectionElement extends ReflectionBase
 		}
 
 		$position = $tokenStream->key();
+
 		if ($tokenStream->is(T_DOC_COMMENT, $position - 1)) {
 			$value = $tokenStream->getTokenValue($position - 1);
 			if (self::DOCBLOCK_TEMPLATE_END !== $value) {
 				$this->docComment = new ReflectionAnnotation($this, $value);
 				$this->startPosition--;
 			}
-		} elseif ($tokenStream->is(T_DOC_COMMENT, $position - 2) && substr_count($tokenStream->getTokenValue($position - 1), "\n") < 2) {
+		} elseif ($tokenStream->is(T_DOC_COMMENT, $position - 2)) {
 			$value = $tokenStream->getTokenValue($position - 2);
 			if (self::DOCBLOCK_TEMPLATE_END !== $value) {
 				$this->docComment = new ReflectionAnnotation($this, $value);

--- a/tests/TokenReflection/ReflectionBrokerTest.php
+++ b/tests/TokenReflection/ReflectionBrokerTest.php
@@ -98,6 +98,7 @@ class ReflectionBrokerTest extends Test
 					'doc-comment.php',
 					'doc-comment-copydoc.php',
 					'doc-comment-inheritance.php',
+					'doc-comment-many-lines.php',
 					'double-properties.php',
 					'final.php',
 					'in-namespace.php',

--- a/tests/TokenReflection/ReflectionClassTest.php
+++ b/tests/TokenReflection/ReflectionClassTest.php
@@ -632,6 +632,20 @@ class ReflectionClassTest extends Test
 		$this->assertFalse($rfl->token->getDocComment());
 	}
 
+    /**
+     * Test getting of documentation comment, when after docComment many line breaks.
+     */
+    public function testDocCommentManyLines()
+    {
+		$rfl = $this->getClassReflection('docCommentManyLines');
+		$this->assertSame($rfl->internal->getDocComment(), $rfl->token->getDocComment());
+		$this->assertSame("/**\n * TokenReflection_Test_ClassDocCommentManyLines.\n *\n * @copyright Copyright (c) 2011\n * @author author\n * @see http://php.net\n */", $rfl->token->getDocComment());
+
+		$rfl = $this->getClassReflection('noDocComment');
+		$this->assertSame($rfl->internal->getDocComment(), $rfl->token->getDocComment());
+		$this->assertFalse($rfl->token->getDocComment());
+    }
+
 	/**
 	 * Tests getting of inherited documentation comment.
 	 */

--- a/tests/data/class/doc-comment-many-lines.php
+++ b/tests/data/class/doc-comment-many-lines.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * TokenReflection_Test_ClassDocCommentManyLines.
+ *
+ * @copyright Copyright (c) 2011
+ * @author author
+ * @see http://php.net
+ */
+
+
+
+
+
+
+
+
+
+
+
+class TokenReflection_Test_ClassDocCommentManyLines
+{
+}


### PR DESCRIPTION
Hi.

I added test and fix problem with docComments, when after docBlock many line breaks.
Example:

``` php
<?php

/**
 * TokenReflection_Test_ClassDocCommentManyLines.
 *
 * @copyright Copyright (c) 2011
 * @author author
 * @see http://php.net
 */











class TokenReflection_Test_ClassDocCommentManyLines
{
}
```
