### PR TITLE
Invalid namespace detection if file has declare

### DIFF
--- a/TokenReflection/ReflectionFile.php
+++ b/TokenReflection/ReflectionFile.php
@@ -110,7 +110,6 @@ class ReflectionFile extends ReflectionBase
 						$tokenStream
 							->skipWhitespaces()
 							->findMatchingBracket()
-							->skipWhitespaces()
 							->skipWhitespaces();
 						break;
 					case T_NAMESPACE:

--- a/tests/TokenReflection/ReflectionFileTest.php
+++ b/tests/TokenReflection/ReflectionFileTest.php
@@ -88,6 +88,40 @@ class ReflectionFileTest extends Test
 		$this->assertSame($this->getBroker()->getFile($fileName), $rfl->token->getFileReflection());
 	}
 
+	public function testDeclareNoNamespace()
+	{
+		$fileName = $this->getFilePath('declareNoNamespace');
+		$this->getBroker()->processFile($fileName);
+
+		$this->assertTrue($this->getBroker()->hasFile($fileName));
+
+		$fileReflection = $this->getBroker()->getFile($fileName);
+		$this->assertInstanceOf('\TokenReflection\ReflectionFile', $fileReflection);
+
+		$this->assertSame($this->getFilePath('declareNoNamespace'), $fileReflection->getPrettyName());
+
+		$namespaces = $fileReflection->getNamespaces();
+		$this->assertCount(1, $namespaces);
+		$this->assertEquals(ReflectionNamespace::NO_NAMESPACE_NAME, $namespaces[0]->getName());
+	}
+
+	public function testDeclareNamespace()
+	{
+		$fileName = $this->getFilePath('declareNamespace');
+		$this->getBroker()->processFile($fileName);
+
+		$this->assertTrue($this->getBroker()->hasFile($fileName));
+
+		$fileReflection = $this->getBroker()->getFile($fileName);
+		$this->assertInstanceOf('\TokenReflection\ReflectionFile', $fileReflection);
+
+		$this->assertSame($this->getFilePath('declareNamespace'), $fileReflection->getPrettyName());
+
+		$namespaces = $fileReflection->getNamespaces();
+		$this->assertCount(1, $namespaces);
+		$this->assertEquals('TokenReflection\Test', $namespaces[0]->getName());
+	}
+
 	/**
 	 * Tests throwing exceptions when requesting reflections of files that were not processed.
 	 *

--- a/tests/data/file/declare-namespace.php
+++ b/tests/data/file/declare-namespace.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(ticks = 1000);
+
+namespace TokenReflection\Test;
+
+class DeclareClassInNamespace
+{
+}

--- a/tests/data/file/declare-no-namespace.php
+++ b/tests/data/file/declare-no-namespace.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(ticks = 1000);
+
+class DeclareClassNoNamespace
+{
+}


### PR DESCRIPTION
``` php
<?php

declare(ticks = 1000);

namespace Test;

use Exception as Ex;

abstract class Exception extends Ex
{

}
```

detect no namespace
