### PR TITLE
Change deprecated syntax for array access

### DIFF
--- a/TokenReflection/Broker.php
+++ b/TokenReflection/Broker.php
@@ -281,7 +281,7 @@ class Broker
 					$process = empty($filters);
 					if (!$process) {
 						foreach ((array) $filters as $filter) {
-							$whitelisting = '!' !== $filter{0};
+							$whitelisting = '!' !== $filter[0];
 							if (fnmatch($whitelisting ? $filter : substr($filter, 1), $entry->getPathName(), FNM_NOESCAPE)) {
 								$process = $whitelisting;
 							}

--- a/TokenReflection/Resolver.php
+++ b/TokenReflection/Resolver.php
@@ -37,7 +37,7 @@ class Resolver
 	 */
 	final public static function resolveClassFQN($className, array $aliases, $namespaceName = null)
 	{
-		if ($className{0} == '\\') {
+		if ($className[0] == '\\') {
 			// FQN
 			return ltrim($className, '\\');
 		}


### PR DESCRIPTION
Two instances of the code use a deprecated (as of PHP 8) way of accessing arrays, by using curly braces (`{}`).

This generates a PHP Fatal Error at runtime (tested on PHP 8.0.8):
```
PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported in andrewsville/php-token-reflection/TokenReflection/Broker.php on line 284
```

This PR changes those places to use square braces instead.